### PR TITLE
VR files not copied into dist

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -329,7 +329,8 @@ module.exports = function (grunt) {
             '*.{ico,png,txt}',
             'images/{,*/}*.webp',
             '{,*/}*.html',
-            'styles/fonts/{,*/}*.*'
+            'styles/fonts/{,*/}*.*',
+            'vr/**/*.*'
           ]
         }<% if (includeBootstrap) { %>, {
           expand: true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-cardboard",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Scaffold out a web based Google cardboard VR experience",
   "author": "Jeshua Maxey (https://jeshua.co)",
   "license": "BSD",


### PR DESCRIPTION
Fix broken distribution by blanket copying all files in `vr/` corresponding directory in `dist/`. This addresses https://github.com/jeshuamaxey/generator-cardboard/issues/8
